### PR TITLE
Add "forall" type quantifier to activate ScopedTypeVariables.

### DIFF
--- a/haskell/parsing_redo/Parser.hs
+++ b/haskell/parsing_redo/Parser.hs
@@ -61,7 +61,7 @@ character = MkParser (\s -> if s == []
 (MkParser p1) ||| (MkParser p2) = MkParser $ \s -> case p1 s of Just (r, c) -> Just (r, c)
                                                                 Nothing     -> p2 s
 
-mapParser :: Parser a -> (a -> b) -> Parser b
+mapParser :: forall a b. Parser a -> (a -> b) -> Parser b
 -- mapParser (MkParser p) f = MkParser (\s -> case p s of Just (r, c) -> Just (r, f c)
 --                                                        Nothing -> Nothing)
 mapParser (MkParser (p :: String -> Maybe (String, a))) (f :: a -> b) = MkParser body


### PR DESCRIPTION
A type variable is "scoped" when both:
- the `ScopedTypeVariables` extension is enabled, for example in a `LANGUAGE` pragma, and
- the type variable is _explicitly_ `forall`-quantified at the desired scope.

Otherwise, the type variable is implicitly scoped to the the type signature in which it appears. In that case, it behaves just as if it had a name distinct from all other type variables in your program.

Thus, without any `forall` quantifiers, each signature gets its own distinct `b` type variable. Internally, GHC gives the `b` in the `mapParser` its original name, and the `b` in the `body` signature the name `b1`.

The thing that is likely confusing you is that when you give "f" an explicit signature `f :: a -> b`, you get a _third_ distinct type variable, say `b2`.

Since this means `f :: forall a b. a -> b`, you'd need to pass a type coercion operator to call `mapParser`! No such function exists in the safe fragment of Haskell. But of course, if you assume someone can pass you such a function, you can trivially use it to satisfy the type checker. Hence, there is no error when this signature is given.

Now here's the trick: when you _remove_ the signature from `f`, it's given an inferred type. The result type inferred from it's use in `body` is the `b` in the signature for `body`, which was internally renamed to `b1`. The result type inferred from its position in the list of arguments to mapParser is the `b` in the signature for `mapParser`. Both of these are fixed ("rigid") by their respective signatures, so neither can be instantiated to the other. BOOM!

But clearly, you intended the `b` in the signature for `body` to refer to the `b` in the signature for `mapParser`, and the way to tell GHC this is to add the `forall` quantifier to the signature for `mapParser`.

Hope that helps!
